### PR TITLE
Sim API に unit_type を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cat emap_plans.json | jq
 ```sh
 # curlの場合
 curl -X POST -H "Content-Type: application/json" -H "X-EMAP-USER-KEY:emapapidemouser1234" -d @req-sample-gas-tepco.json https://emap-sim-base.enechange.jp/v001/elec/simulate > emap_simulation.json
-curl -X POST -H "Content-Type: application/json" -H "X-EMAP-USER-KEY:emapapidemouser1234" -d '{"request_id":"E00001","postcode":"1000004","fee_plan_code":"ozkxj|hzozmtmvoztgdbcodibtw-ozkxj","contract_ampere":40,"base_YYYYmm":"202010","fee_history":["8000","","","","","","","","","","",""],"usage_history":["","","","","","","","","","","",""],"weekday_night_usage_percentage":25,"all_electric":false,"fee_plan_codes":["ozkxj|hzozmtmvoztgdbcodibtw-ozkxj","nvhkgzvbvn|hzozmtmvoztgdbcodibtw-ozkxj","nvhkgzvbvn|hzozmtmvoztgdbcodibtwtb-ozkxj"]}' https://emap-sim-base.enechange.jp/v001/elec/simulate > emap_simulation.json
+curl -X POST -H "Content-Type: application/json" -H "X-EMAP-USER-KEY:emapapidemouser1234" -d '{"request_id":"E00001","postcode":"1000004","fee_plan_code":"ozkxj|hzozmtmvoztgdbcodibtw-ozkxj","contract_ampere":40,"unit_type":1,"base_YYYYmm":"202010","fee_history":["8000","","","","","","","","","","",""],"usage_history":["","","","","","","","","","","",""],"weekday_night_usage_percentage":25,"all_electric":false,"fee_plan_codes":["ozkxj|hzozmtmvoztgdbcodibtw-ozkxj","nvhkgzvbvn|hzozmtmvoztgdbcodibtw-ozkxj","nvhkgzvbvn|hzozmtmvoztgdbcodibtwtb-ozkxj"]}' https://emap-sim-base.enechange.jp/v001/elec/simulate > emap_simulation.json
 
 # wgetの場合
 wget -q -O emap_simulation.json https://emap-sim-base.enechange.jp/v001/elec/simulate --post-file req-sample-gas-tepco.json --header='X-EMAP-USER-KEY:emapapidemouser1234' --header 'Content-Type: application/json' --header 'Accept: application/json'

--- a/sample_requests/req-sample-gas-tepco.json
+++ b/sample_requests/req-sample-gas-tepco.json
@@ -3,6 +3,7 @@
   "postcode": "1000004",
   "fee_plan_code": "ozkxj|hzozmtmvoztgdbcodibtw-ozkxj",
   "contract_ampere": 40,
+  "unit_type": 1,
   "base_YYYYmm": "202010",
   "fee_history": [
     "8000",
@@ -33,10 +34,6 @@
     ""
   ],
   "weekday_night_usage_percentage": 25,
-  "holiday_night_usage_percentage": null,
-  "floor_space": 45,
-  "number_of_rooms": 2,
-  "number_of_family": 3,
   "all_electric": false,
   "fee_plan_codes": [
     "ozkxj|hzozmtmvoztgdbcodibtw-ozkxj",


### PR DESCRIPTION
- Sim API に unit_type を追加
- ついでに必須でないパラメータを削除

なおすでに demo には unit_type の追加を反映済みなので、このドキュメント・サンプルを更新しても動作に齟齬は出ません。